### PR TITLE
Translations update from Translate H5P

### DIFF
--- a/language/pt.json
+++ b/language/pt.json
@@ -6,11 +6,11 @@
     },
     {},
     {
-      "label": "Export not supported label",
-      "default": "Export not supported on your device"
+      "label": "Etiqueta de exportação não suportada",
+      "default": "Exportação não suportada no seu dispositivo"
     },
     {
-      "label": "Include comments in the exported document"
+      "label": "Incluir comentários no documento exportado"
     }
   ]
 }

--- a/language/sv.json
+++ b/language/sv.json
@@ -2,15 +2,15 @@
   "semantics": [
     {
       "label": "Label",
-      "description": "Label/heading for answer when user exports all answers"
+      "description": "Etikett/rubrik för svar när användaren exporterar alla svar"
     },
     {},
     {
-      "label": "Export not supported label",
-      "default": "Export not supported on your device"
+      "label": "Etikett för att export inte stöds",
+      "default": "Export stöds inte på din enhet"
     },
     {
-      "label": "Include comments in the exported document"
+      "label": "Inkludera kommentarer i det exporterade dokumentet"
     }
   ]
 }


### PR DESCRIPTION
Translations update from [Translate H5P](https://translate-h5p.tk) for [H5P/h5p-exportable-text-area](https://translate-h5p.tk/weblate/projects/h5p/h5p-exportable-text-area/).



Current translation status:

![Weblate translation status](https://translate-h5p.tk/weblate/widgets/h5p/-/h5p-exportable-text-area/horizontal-auto.svg)